### PR TITLE
Support readcount

### DIFF
--- a/app/api/fastq_manager_api_tools/models/fastq_pair.py
+++ b/app/api/fastq_manager_api_tools/models/fastq_pair.py
@@ -114,6 +114,11 @@ class FastqPairStorageObjectResponse(FastqPairStorageObjectBase):
         data['r1'] = self.r1.model_dump(**kwargs, include_s3_details=include_s3_details)
         if self.r2:
             data['r2'] = self.r2.model_dump(**kwargs, include_s3_details=include_s3_details)
+
+        # If compression format is None and include_s3_details is True, we can retrieve it from r1 or r2
+        if self.compression_format is None and include_s3_details:
+            data['compressionFormat'] = "ORA" if data['r1']['s3Uri'].endswith(".ora") else "GZIP"
+
         return data
 
 

--- a/app/api/fastq_manager_api_tools/utils.py
+++ b/app/api/fastq_manager_api_tools/utils.py
@@ -279,7 +279,7 @@ def get_libraries_from_metadata_query(
             ))
         ))
 
-    return library_list
+    return list(set(library_list))  # Remove duplicates
 
 
 # AWS Things

--- a/app/ecs/get_base_count_est/docker-entrypoint.sh
+++ b/app/ecs/get_base_count_est/docker-entrypoint.sh
@@ -82,7 +82,7 @@ multiplier="$( \
 
 # Get the final estimate
 basecount_est="$( \
-  python3 -c "print( ${basecount_est} * ${multiplier} )" \
+  python3 -c "print(int( ${basecount_est} * ${multiplier} ))" \
 )"
 
 # Write the file size to the output uri

--- a/app/lambdas/get_fastq_object_with_s3_objs_py/get_fastq_object_with_s3_objs.py
+++ b/app/lambdas/get_fastq_object_with_s3_objs_py/get_fastq_object_with_s3_objs.py
@@ -46,3 +46,23 @@ def handler(event, context) -> Dict[str, Union[str, List[S3Obj]]]:
         "fastqObj": fastq_obj,
         "s3Objs": s3_objs,
     }
+
+
+# if __name__ == "__main__":
+#     from os import environ
+#     import json
+#
+#     environ['AWS_PROFILE'] = 'umccr-production'
+#     environ['AWS_REGION'] = 'ap-southeast-2'
+#     environ['HOSTNAME_SSM_PARAMETER_NAME'] = '/hosted_zone/umccr/name'
+#     environ['ORCABUS_TOKEN_SECRET_ID'] = 'orcabus/token-service-jwt'
+#
+#     print(json.dumps(
+#         handler(
+#             {
+#                 "fastqId": "fqr.01JN26HNGR2RK042S3X58S1WSW"
+#             },
+#             None
+#         ),
+#         indent=4
+#     ))

--- a/app/step-functions-templates/run_file_compression_stats_sfn_template.asl.json
+++ b/app/step-functions-templates/run_file_compression_stats_sfn_template.asl.json
@@ -243,7 +243,16 @@
                 ]
               }
             },
-            "Next": "Get raw md5sum output contents"
+            "Next": "Get raw md5sum output contents",
+            "Retry": [
+              {
+                "ErrorEquals": ["ECS.AmazonECSException"],
+                "BackoffRate": 2,
+                "IntervalSeconds": 20,
+                "MaxAttempts": 3,
+                "JitterStrategy": "FULL"
+              }
+            ]
           },
           "Get raw md5sum output contents": {
             "Type": "Task",

--- a/app/step-functions-templates/run_qc_stats_sfn_template.asl.json
+++ b/app/step-functions-templates/run_qc_stats_sfn_template.asl.json
@@ -85,7 +85,7 @@
           }
         ]
       },
-      "Next": "Run Sequali and upload to s3",
+      "Next": "Get Fastq Object (for read count / basecount)",
       "Catch": [
         {
           "ErrorEquals": ["States.TaskFailed"],
@@ -97,6 +97,35 @@
       ],
       "Assign": {
         "s3Objs": "{% (\n    $getFastqIngestIdList := function($decompressedFileList, $fastqId) {(\n        /* Start with the decompressedFileList input */\n        $decompressedFileList ~>\n        /* Get the only item in the list where the fastq id matches */\n        $single(\n            function($decompressedFileListIter){\n                $decompressedFileListIter.fastqId = $fastqId\n            }\n        ) ~>\n        /* Get the ingest id list */\n        $lookup('decompressedFileUriByOraFileIngestIdList')\n    )};\n    $getR1FileObjFilter := function($s3ObjIter){\n        $s3ObjIter.ingestId = $s3Objs[0].ingestId\n    };\n    $getR2FileObjFilter := function($s3ObjIter) {(\n        $s3ObjIter.ingestId = $s3Objs[1].ingestId\n    )};\n    $getFileUri := function($fastqFileList, $filterFunction){\n        /* Start with the fastq file list */\n        $fastqFileList ~>\n        /* Pipe into single, which collects the filter function */\n        $single($filterFunction) ~>\n        /* And then get the gzipFileUri attribute */\n        $lookup('gzipFileUri')\n    };\n\n    /* Start with the decompressedFileList input */\n    $fastqFileList := $getFastqIngestIdList(\n        $states.result.decompressedFileList,\n        $fastqId\n    );\n\n    /* Collect the iterable that matches the ingest id */\n    [\n        {\n            's3Uri': ($fastqFileList ~> $getFileUri($getR1FileObjFilter))\n        },\n        {\n            's3Uri': ($fastqFileList ~> $getFileUri($getR2FileObjFilter))\n        }\n    ]\n) %}"
+      }
+    },
+    "Get Fastq Object (for read count / basecount)": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "Output": "{% $states.result.Payload %}",
+      "Arguments": {
+        "FunctionName": "${__get_fastq_object_with_s3_objs_lambda_function_arn__}",
+        "Payload": {
+          "fastqId": "{% $fastqId %}"
+        }
+      },
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "Lambda.ServiceException",
+            "Lambda.AWSLambdaException",
+            "Lambda.SdkClientException",
+            "Lambda.TooManyRequestsException"
+          ],
+          "IntervalSeconds": 1,
+          "MaxAttempts": 3,
+          "BackoffRate": 2,
+          "JitterStrategy": "FULL"
+        }
+      ],
+      "Next": "Run Sequali and upload to s3",
+      "Assign": {
+        "fastqObj": "{% $states.result.Payload.fastqObj %}"
       }
     },
     "Run Sequali and upload to s3": {
@@ -178,7 +207,16 @@
       ],
       "Assign": {
         "jobStatus": "SUCCEEDED"
-      }
+      },
+      "Retry": [
+        {
+          "ErrorEquals": ["ECS.AmazonECSException"],
+          "BackoffRate": 2,
+          "IntervalSeconds": 20,
+          "MaxAttempts": 3,
+          "JitterStrategy": "FULL"
+        }
+      ]
     },
     "Get sequali outputs": {
       "Type": "Task",

--- a/app/step-functions-templates/run_read_count_stats_sfn_template.asl.json
+++ b/app/step-functions-templates/run_read_count_stats_sfn_template.asl.json
@@ -100,7 +100,7 @@
         }
       ],
       "Assign": {
-        "readCount": "{% $single(\n  $states.result.Output.readCountList, \n  function($readCountListIter){\n    $readCountListIter.fastqId = $fastqId\n  }\n).readCount %}"
+        "readCount": "{% $single(\n  $states.result.readCountList, \n  function($readCountListIter){\n    $readCountListIter.fastqId = $fastqId\n  }\n).readCount %}"
       }
     },
     "ECS Run ReadCount": {
@@ -143,6 +143,15 @@
           "Assign": {
             "jobStatus": "FAILED"
           }
+        }
+      ],
+      "Retry": [
+        {
+          "ErrorEquals": ["ECS.AmazonECSException"],
+          "BackoffRate": 2,
+          "IntervalSeconds": 20,
+          "MaxAttempts": 3,
+          "JitterStrategy": "FULL"
         }
       ]
     },
@@ -212,12 +221,12 @@
               "Name": "${__get_base_count_est_container_name__}",
               "Environment": [
                 {
-                  "Name": "R1_INPUT_URI",
+                  "Name": "READ_INPUT_URI",
                   "Value": "{% $s3Objs[0].s3Uri %}"
                 },
                 {
-                  "Name": "R2_INPUT_URI",
-                  "Value": "{% $s3Objs[1] != null ? $s3Objs[1].s3Uri : null %}"
+                  "Name": "READ_COUNT",
+                  "Value": "{% $string($readCount) %}"
                 },
                 {
                   "Name": "OUTPUT_URI",
@@ -241,7 +250,16 @@
       ],
       "Assign": {
         "jobStatus": "SUCCEEDED"
-      }
+      },
+      "Retry": [
+        {
+          "ErrorEquals": ["ECS.AmazonECSException"],
+          "BackoffRate": 2,
+          "IntervalSeconds": 20,
+          "MaxAttempts": 3,
+          "JitterStrategy": "FULL"
+        }
+      ]
     },
     "Get Base Count Object": {
       "Type": "Task",


### PR DESCRIPTION
Also:
* Add retries for ecs capacity failures
* Recollect fastq object after decompression, since read counts may have been updated
* Basecount must be an int
* Drop library metadata duplicates
* Get compression format if null and include s3 details set to true