### PR TITLE
Only 'set' the library id list if it's not None

### DIFF
--- a/app/api/fastq_manager_api_tools/utils.py
+++ b/app/api/fastq_manager_api_tools/utils.py
@@ -279,7 +279,8 @@ def get_libraries_from_metadata_query(
             ))
         ))
 
-    return list(set(library_list))  # Remove duplicates
+    if library_list is not None:
+        return list(set(library_list))  # Remove duplicates
 
 
 # AWS Things


### PR DESCRIPTION
Fixes 500 error if only the instrument run id is used in the query