### PR TITLE
Feature assign readCount var if readCounts already exists

### DIFF
--- a/app/step-functions-templates/run_read_count_stats_sfn_template.asl.json
+++ b/app/step-functions-templates/run_read_count_stats_sfn_template.asl.json
@@ -54,7 +54,10 @@
         {
           "Next": "Is ORA (base count)",
           "Condition": "{% $fastqObj.readCount != null %}",
-          "Comment": "Has ReadCount"
+          "Comment": "Has ReadCount",
+          "Assign": {
+            "readCount": "{% $fastqObj.readCount %}"
+          }
         }
       ],
       "Default": "Is ORA (read count)"


### PR DESCRIPTION
Assign readCount SFN var if readCount already exists, fixes error when readCount exists but baseCount est still needs to be calculated