### PR TITLE
Integrates filemanager sync into NTSM/QC SFNs

### DIFF
--- a/app/lambdas/filemanager_sync_py/filemanager_sync.py
+++ b/app/lambdas/filemanager_sync_py/filemanager_sync.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+
+"""
+Run filemanager sync after uploading
+"""
+
+
+# Local imports
+from orcabus_api_tools.filemanager import crawl_filemanager_sync
+
+
+def handler(event, context):
+    """
+    Sync filemanager at prefix
+    :param event:
+    :param context:
+    :return:
+    """
+
+    # Inputs
+    bucket = event['bucket']
+    prefix = event['prefix']
+
+    # Run crawl filemanager sync
+    crawl_filemanager_sync(
+        bucket=bucket,
+        prefix=prefix
+    )

--- a/app/step-functions-templates/run_ntsm_count_sfn_template.asl.json
+++ b/app/step-functions-templates/run_ntsm_count_sfn_template.asl.json
@@ -169,12 +169,39 @@
       "Type": "Choice",
       "Choices": [
         {
-          "Next": "Update fastq object",
+          "Next": "Sync filemanager",
           "Condition": "{% $jobStatus = 'SUCCEEDED' %}",
           "Comment": "Update Fastq Object"
         }
       ],
       "Default": "Pass"
+    },
+    "Sync filemanager": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "Output": "{% $states.result.Payload %}",
+      "Arguments": {
+        "Payload": {
+          "bucket": "{% $ntsmBucket %}",
+          "prefix": "{% $ntsmKey %}"
+        },
+        "FunctionName": "${__filemanager_sync_lambda_function_arn__}"
+      },
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "Lambda.ServiceException",
+            "Lambda.AWSLambdaException",
+            "Lambda.SdkClientException",
+            "Lambda.TooManyRequestsException"
+          ],
+          "IntervalSeconds": 1,
+          "MaxAttempts": 3,
+          "BackoffRate": 2,
+          "JitterStrategy": "FULL"
+        }
+      ],
+      "Next": "Update fastq object"
     },
     "Update fastq object": {
       "Type": "Task",

--- a/app/step-functions-templates/run_ntsm_count_sfn_template.asl.json
+++ b/app/step-functions-templates/run_ntsm_count_sfn_template.asl.json
@@ -169,12 +169,17 @@
       "Type": "Choice",
       "Choices": [
         {
-          "Next": "Sync filemanager",
+          "Next": "Wait 5 Seconds for Filemanager to sync",
           "Condition": "{% $jobStatus = 'SUCCEEDED' %}",
           "Comment": "Update Fastq Object"
         }
       ],
       "Default": "Pass"
+    },
+    "Wait 5 Seconds for Filemanager to sync": {
+      "Type": "Wait",
+      "Seconds": 5,
+      "Next": "Sync filemanager"
     },
     "Sync filemanager": {
       "Type": "Task",

--- a/app/step-functions-templates/run_qc_stats_sfn_template.asl.json
+++ b/app/step-functions-templates/run_qc_stats_sfn_template.asl.json
@@ -344,12 +344,39 @@
       "Type": "Choice",
       "Choices": [
         {
-          "Next": "Update fastq object",
+          "Next": "Sync Filemanager",
           "Condition": "{% $jobStatus = 'SUCCEEDED' %}",
           "Comment": "Job Status Is Succeeded"
         }
       ],
       "Default": "Fail"
+    },
+    "Sync Filemanager": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "Output": "{% $states.result.Payload %}",
+      "Arguments": {
+        "FunctionName": "${__filemanager_sync_lambda_function_arn__}",
+        "Payload": {
+          "bucket": "{% $sequaliBucket %}",
+          "prefix": "{% $sequaliMidFix %}"
+        }
+      },
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "Lambda.ServiceException",
+            "Lambda.AWSLambdaException",
+            "Lambda.SdkClientException",
+            "Lambda.TooManyRequestsException"
+          ],
+          "IntervalSeconds": 1,
+          "MaxAttempts": 3,
+          "BackoffRate": 2,
+          "JitterStrategy": "FULL"
+        }
+      ],
+      "Next": "Update fastq object"
     },
     "Update fastq object": {
       "Type": "Task",

--- a/app/step-functions-templates/run_qc_stats_sfn_template.asl.json
+++ b/app/step-functions-templates/run_qc_stats_sfn_template.asl.json
@@ -344,12 +344,17 @@
       "Type": "Choice",
       "Choices": [
         {
-          "Next": "Sync Filemanager",
+          "Next": "Wait for Filemanager to Sync",
           "Condition": "{% $jobStatus = 'SUCCEEDED' %}",
           "Comment": "Job Status Is Succeeded"
         }
       ],
       "Default": "Fail"
+    },
+    "Wait for Filemanager to Sync": {
+      "Type": "Wait",
+      "Seconds": 5,
+      "Next": "Sync Filemanager"
     },
     "Sync Filemanager": {
       "Type": "Task",

--- a/infrastructure/stage/lambdas/interfaces.ts
+++ b/infrastructure/stage/lambdas/interfaces.ts
@@ -13,6 +13,7 @@ export type LambdaNameList =
   // Shared Job functions
   | 'getFastqObjectsInFastqSet'
   | 'getFastqObjectWithS3Objs'
+  | 'filemanagerSync'
   // Job updater functions
   | 'updateFastqObject'
   | 'updateJobObject'
@@ -36,6 +37,7 @@ export const lambdaNameList: LambdaNameList[] = [
   // Shared Job functions
   'getFastqObjectsInFastqSet',
   'getFastqObjectWithS3Objs',
+  'filemanagerSync',
   // Job updater functions
   'updateFastqObject',
   'updateJobObject',
@@ -74,10 +76,14 @@ export const lambdaRequirementsMap: Record<LambdaNameList, LambdaRequirementsPro
     needsLargeEphemeralStorage: true,
   },
   checkRelatednessList: {},
+  // Shared job functions
   getFastqObjectsInFastqSet: {
     needsOrcabusApiTools: true,
   },
   getFastqObjectWithS3Objs: {
+    needsOrcabusApiTools: true,
+  },
+  filemanagerSync: {
     needsOrcabusApiTools: true,
   },
   // Job updater functions

--- a/infrastructure/stage/step-functions/interfaces.ts
+++ b/infrastructure/stage/step-functions/interfaces.ts
@@ -98,7 +98,12 @@ export const stepFunctionRequirementsMap: Record<StepFunctionName, StepFunctionR
 // Map the lambda functions to their step function names
 export const stepFunctionLambdaMap: Record<StepFunctionName, LambdaNameList[]> = {
   // NSTM Counts
-  runNtsmCount: ['getFastqObjectWithS3Objs', 'updateFastqObject', 'updateJobObject'],
+  runNtsmCount: [
+    'getFastqObjectWithS3Objs',
+    'updateFastqObject',
+    'updateJobObject',
+    'filemanagerSync',
+  ],
   // NSTM Evaluations
   runNtsmEvalX: ['ntsmEval', 'getFastqObjectsInFastqSet', 'checkRelatednessList'],
   runNtsmEvalXY: ['getFastqObjectsInFastqSet', 'ntsmEval', 'checkRelatednessList'],

--- a/infrastructure/stage/step-functions/interfaces.ts
+++ b/infrastructure/stage/step-functions/interfaces.ts
@@ -115,6 +115,7 @@ export const stepFunctionLambdaMap: Record<StepFunctionName, LambdaNameList[]> =
     'updateJobObject',
     'updateFastqObject',
     'calculateEphemeralSize',
+    'filemanagerSync',
   ],
   // File Compression Stats
   runFileCompressionStats: ['getFastqObjectWithS3Objs', 'updateJobObject', 'updateFastqObject'],


### PR DESCRIPTION
Adds a `filemanagerSync` Lambda function and integrates it into the `runNtsmCount` and `runQcStats` Step Functions. This ensures that the file manager is synchronized immediately after successful processing, improving data visibility and consistency for newly generated or updated files.

-   **New Functionality:**
    -   Introduces a new Python Lambda function, `filemanager_sync.py`, which triggers a file manager crawl for a specified S3 bucket and prefix using `orcabus_api_tools`.
    -   Registers the `filemanagerSync` Lambda within the infrastructure interfaces, making it available for deployment and use.

-   **Workflow Enhancements:**
    -   Updates the `run_ntsm_count` Step Function to include a `Sync filemanager` task. This task invokes the new `filemanagerSync` Lambda after a job successfully completes, before proceeding to update the Fastq object.
    -   Updates the `run_qc_stats` Step Function with a similar `Sync Filemanager` task, ensuring the file manager is synchronized after its jobs succeed.
    -   Updates infrastructure mappings to correctly associate the `filemanagerSync` Lambda with these Step Functions.