### PR TITLE
Enhances filemanager sync with verification and retries

### DIFF
--- a/app/lambdas/filemanager_sync_and_check_py/filemanager_sync_and_check.py
+++ b/app/lambdas/filemanager_sync_and_check_py/filemanager_sync_and_check.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+
+"""
+Run filemanager sync and check if files exist in the filemanager
+"""
+
+
+# Local imports
+from orcabus_api_tools.filemanager import (
+    crawl_filemanager_sync,
+    get_ingest_id_from_s3_uri,
+)
+
+
+def handler(event, context):
+    """
+    Sync filemanager at prefix and check if all files exist
+    :param event:
+    :param context:
+    :return:
+    """
+
+    # Inputs
+    if 'bucket' not in event:
+        raise KeyError("Missing required field 'bucket' in event")
+    if 'keys' not in event:
+        raise KeyError("Missing required field 'keys' in event")
+    if 'prefix' not in event:
+        raise KeyError("Missing required field 'prefix' in event")
+
+    bucket = event['bucket']
+    keys = event['keys']
+    prefix = event['prefix']
+
+    if not keys:
+        raise ValueError("'keys' must be a non-empty list")
+
+    # Run crawl filemanager sync
+    crawl_filemanager_sync(
+        bucket=bucket,
+        prefix=prefix
+    )
+
+    # Check if each key exists in the filemanager
+    ingest_ids = {}
+    for key in keys:
+        s3_uri = f"s3://{bucket}/{key}"
+        try:
+            ingest_id = get_ingest_id_from_s3_uri(s3_uri)
+            ingest_ids[key] = ingest_id
+        except Exception:
+            # Key not found in filemanager, skip
+            pass
+
+    return {
+        "allFilesExist": len(ingest_ids) == len(keys),
+        "ingestIds": ingest_ids
+    }

--- a/app/step-functions-templates/run_ntsm_count_sfn_template.asl.json
+++ b/app/step-functions-templates/run_ntsm_count_sfn_template.asl.json
@@ -169,28 +169,31 @@
       "Type": "Choice",
       "Choices": [
         {
-          "Next": "Wait 5 Seconds for Filemanager to sync",
+          "Next": "Initialize Sync Retry Count",
           "Condition": "{% $jobStatus = 'SUCCEEDED' %}",
           "Comment": "Update Fastq Object"
         }
       ],
       "Default": "Pass"
     },
-    "Wait 5 Seconds for Filemanager to sync": {
-      "Type": "Wait",
-      "Seconds": 5,
-      "Next": "Sync filemanager"
+    "Initialize Sync Retry Count": {
+      "Type": "Pass",
+      "Assign": {
+        "syncRetryCount": 0
+      },
+      "Next": "Sync and Check Filemanager"
     },
-    "Sync filemanager": {
+    "Sync and Check Filemanager": {
       "Type": "Task",
       "Resource": "arn:aws:states:::lambda:invoke",
       "Output": "{% $states.result.Payload %}",
       "Arguments": {
+        "FunctionName": "${__filemanager_sync_and_check_lambda_function_arn__}",
         "Payload": {
           "bucket": "{% $ntsmBucket %}",
+          "keys": ["{% $ntsmKey %}"],
           "prefix": "{% $ntsmKey %}"
-        },
-        "FunctionName": "${__filemanager_sync_lambda_function_arn__}"
+        }
       },
       "Retry": [
         {
@@ -206,7 +209,40 @@
           "JitterStrategy": "FULL"
         }
       ],
-      "Next": "Update fastq object"
+      "Next": "All Files Exist?"
+    },
+    "All Files Exist?": {
+      "Type": "Choice",
+      "Choices": [
+        {
+          "Next": "Update fastq object",
+          "Condition": "{% $states.result.allFilesExist = true %}",
+          "Comment": "All files are indexed"
+        },
+        {
+          "Next": "Sync Check Failed",
+          "Condition": "{% $states.result.allFilesExist = false and $syncRetryCount >= 12 %}",
+          "Comment": "Max retries exceeded"
+        }
+      ],
+      "Default": "Wait Before Retry"
+    },
+    "Wait Before Retry": {
+      "Type": "Wait",
+      "Seconds": 5,
+      "Next": "Increment Retry Count"
+    },
+    "Increment Retry Count": {
+      "Type": "Pass",
+      "Assign": {
+        "syncRetryCount": "{% $syncRetryCount + 1 %}"
+      },
+      "Next": "Sync and Check Filemanager"
+    },
+    "Sync Check Failed": {
+      "Type": "Fail",
+      "Error": "SyncCheckFailed",
+      "Cause": "Filemanager sync check failed after 12 retries"
     },
     "Update fastq object": {
       "Type": "Task",

--- a/app/step-functions-templates/run_ntsm_count_sfn_template.asl.json
+++ b/app/step-functions-templates/run_ntsm_count_sfn_template.asl.json
@@ -216,12 +216,12 @@
       "Choices": [
         {
           "Next": "Update fastq object",
-          "Condition": "{% $states.result.allFilesExist = true %}",
+          "Condition": "{% $states.input.allFilesExist = true %}",
           "Comment": "All files are indexed"
         },
         {
           "Next": "Sync Check Failed",
-          "Condition": "{% $states.result.allFilesExist = false and $syncRetryCount >= 12 %}",
+          "Condition": "{% $states.input.allFilesExist = false and $syncRetryCount >= 12 %}",
           "Comment": "Max retries exceeded"
         }
       ],

--- a/app/step-functions-templates/run_qc_stats_sfn_template.asl.json
+++ b/app/step-functions-templates/run_qc_stats_sfn_template.asl.json
@@ -366,7 +366,12 @@
         "FunctionName": "${__filemanager_sync_and_check_lambda_function_arn__}",
         "Payload": {
           "bucket": "{% $sequaliBucket %}",
-          "keys": ["{% $sequaliHtmlKey %}", "{% $sequaliParquetKey %}", "{% $multiqcHtmlKey %}", "{% $multiqcParquetKey %}"],
+          "keys": [
+            "{% $sequaliHtmlKey %}",
+            "{% $sequaliParquetKey %}",
+            "{% $multiqcHtmlKey %}",
+            "{% $multiqcParquetKey %}"
+          ],
           "prefix": "{% $sequaliMidFix %}"
         }
       },

--- a/app/step-functions-templates/run_qc_stats_sfn_template.asl.json
+++ b/app/step-functions-templates/run_qc_stats_sfn_template.asl.json
@@ -344,26 +344,29 @@
       "Type": "Choice",
       "Choices": [
         {
-          "Next": "Wait for Filemanager to Sync",
+          "Next": "Initialize Sync Retry Count",
           "Condition": "{% $jobStatus = 'SUCCEEDED' %}",
           "Comment": "Job Status Is Succeeded"
         }
       ],
       "Default": "Fail"
     },
-    "Wait for Filemanager to Sync": {
-      "Type": "Wait",
-      "Seconds": 5,
-      "Next": "Sync Filemanager"
+    "Initialize Sync Retry Count": {
+      "Type": "Pass",
+      "Assign": {
+        "syncRetryCount": 0
+      },
+      "Next": "Sync and Check Filemanager"
     },
-    "Sync Filemanager": {
+    "Sync and Check Filemanager": {
       "Type": "Task",
       "Resource": "arn:aws:states:::lambda:invoke",
       "Output": "{% $states.result.Payload %}",
       "Arguments": {
-        "FunctionName": "${__filemanager_sync_lambda_function_arn__}",
+        "FunctionName": "${__filemanager_sync_and_check_lambda_function_arn__}",
         "Payload": {
           "bucket": "{% $sequaliBucket %}",
+          "keys": ["{% $sequaliHtmlKey %}", "{% $sequaliParquetKey %}", "{% $multiqcHtmlKey %}", "{% $multiqcParquetKey %}"],
           "prefix": "{% $sequaliMidFix %}"
         }
       },
@@ -381,7 +384,40 @@
           "JitterStrategy": "FULL"
         }
       ],
-      "Next": "Update fastq object"
+      "Next": "All Files Exist?"
+    },
+    "All Files Exist?": {
+      "Type": "Choice",
+      "Choices": [
+        {
+          "Next": "Update fastq object",
+          "Condition": "{% $states.result.allFilesExist = true %}",
+          "Comment": "All files are indexed"
+        },
+        {
+          "Next": "Sync Check Failed",
+          "Condition": "{% $states.result.allFilesExist = false and $syncRetryCount >= 12 %}",
+          "Comment": "Max retries exceeded"
+        }
+      ],
+      "Default": "Wait Before Retry"
+    },
+    "Wait Before Retry": {
+      "Type": "Wait",
+      "Seconds": 5,
+      "Next": "Increment Retry Count"
+    },
+    "Increment Retry Count": {
+      "Type": "Pass",
+      "Assign": {
+        "syncRetryCount": "{% $syncRetryCount + 1 %}"
+      },
+      "Next": "Sync and Check Filemanager"
+    },
+    "Sync Check Failed": {
+      "Type": "Fail",
+      "Error": "SyncCheckFailed",
+      "Cause": "Filemanager sync check failed after 12 retries"
     },
     "Update fastq object": {
       "Type": "Task",

--- a/app/step-functions-templates/run_qc_stats_sfn_template.asl.json
+++ b/app/step-functions-templates/run_qc_stats_sfn_template.asl.json
@@ -396,12 +396,12 @@
       "Choices": [
         {
           "Next": "Update fastq object",
-          "Condition": "{% $states.result.allFilesExist = true %}",
+          "Condition": "{% $states.input.allFilesExist = true %}",
           "Comment": "All files are indexed"
         },
         {
           "Next": "Sync Check Failed",
-          "Condition": "{% $states.result.allFilesExist = false and $syncRetryCount >= 12 %}",
+          "Condition": "{% $states.input.allFilesExist = false and $syncRetryCount >= 12 %}",
           "Comment": "Max retries exceeded"
         }
       ],

--- a/infrastructure/stage/lambdas/interfaces.ts
+++ b/infrastructure/stage/lambdas/interfaces.ts
@@ -14,6 +14,7 @@ export type LambdaNameList =
   | 'getFastqObjectsInFastqSet'
   | 'getFastqObjectWithS3Objs'
   | 'filemanagerSync'
+  | 'filemanagerSyncAndCheck'
   // Job updater functions
   | 'updateFastqObject'
   | 'updateJobObject'
@@ -38,6 +39,7 @@ export const lambdaNameList: LambdaNameList[] = [
   'getFastqObjectsInFastqSet',
   'getFastqObjectWithS3Objs',
   'filemanagerSync',
+  'filemanagerSyncAndCheck',
   // Job updater functions
   'updateFastqObject',
   'updateJobObject',
@@ -84,6 +86,9 @@ export const lambdaRequirementsMap: Record<LambdaNameList, LambdaRequirementsPro
     needsOrcabusApiTools: true,
   },
   filemanagerSync: {
+    needsOrcabusApiTools: true,
+  },
+  filemanagerSyncAndCheck: {
     needsOrcabusApiTools: true,
   },
   // Job updater functions

--- a/infrastructure/stage/step-functions/interfaces.ts
+++ b/infrastructure/stage/step-functions/interfaces.ts
@@ -115,7 +115,7 @@ export const stepFunctionLambdaMap: Record<StepFunctionName, LambdaNameList[]> =
     'updateJobObject',
     'updateFastqObject',
     'calculateEphemeralSize',
-    'filemanagerSync',
+    'filemanagerSyncAndCheck',
   ],
   // File Compression Stats
   runFileCompressionStats: ['getFastqObjectWithS3Objs', 'updateJobObject', 'updateFastqObject'],

--- a/infrastructure/stage/step-functions/interfaces.ts
+++ b/infrastructure/stage/step-functions/interfaces.ts
@@ -102,7 +102,7 @@ export const stepFunctionLambdaMap: Record<StepFunctionName, LambdaNameList[]> =
     'getFastqObjectWithS3Objs',
     'updateFastqObject',
     'updateJobObject',
-    'filemanagerSync',
+    'filemanagerSyncAndCheck',
   ],
   // NSTM Evaluations
   runNtsmEvalX: ['ntsmEval', 'getFastqObjectsInFastqSet', 'checkRelatednessList'],


### PR DESCRIPTION
Introduces a new `filemanagerSyncAndCheck` Lambda function. This function synchronizes the filemanager for a specified prefix and then explicitly verifies the existence of a list of S3 keys within the filemanager.

Integrates this new verification step into the NTSM Count and QC Stats Step Functions:
- Replaces the existing `filemanagerSync` task with the new `filemanagerSyncAndCheck` lambda.
- Implements a robust retry mechanism, allowing up to 12 attempts (with a 5-second wait between retries), to ensure that all required files are successfully indexed in the filemanager before the workflow proceeds.
- Updates infrastructure definitions to incorporate the new lambda and its usage in the Step Functions.

This enhancement ensures that critical downstream processes, such as updating fastq or QC objects, only execute once all necessary files are confirmed to be discoverable in the filemanager, thereby preventing failures due to indexing delays.