### PR TITLE
fix(sfn): Add retry policy for sporadic libcurl errors in somalier extract

### DIFF
--- a/app/step-functions-templates/run_somalier_extract_sfn_template.asl.json
+++ b/app/step-functions-templates/run_somalier_extract_sfn_template.asl.json
@@ -250,6 +250,16 @@
           },
           "Next": "Fail"
         }
+      ],
+      "Retry": [
+        {
+          "ErrorEquals": ["States.TaskFailed"],
+          "BackoffRate": 2,
+          "IntervalSeconds": 60,
+          "MaxAttempts": 3,
+          "Comment": "Sporadic Libcurl error",
+          "MaxDelaySeconds": 300
+        }
       ]
     },
     "Get sample metadata": {


### PR DESCRIPTION
Add a Retry clause to the somalier extract ECS task state to handle
transient libcurl failures. Retries up to 3 times with exponential
backoff (60s initial interval, 2x backoff, 300s max delay).
