### PR TITLE
Add retry policies for sporadic libcurl errors

### DIFF
--- a/app/step-functions-templates/run_somalier_extract_sfn_template.asl.json
+++ b/app/step-functions-templates/run_somalier_extract_sfn_template.asl.json
@@ -250,6 +250,16 @@
           },
           "Next": "Fail"
         }
+      ],
+      "Retry": [
+        {
+          "ErrorEquals": ["States.TaskFailed"],
+          "BackoffRate": 2,
+          "IntervalSeconds": 60,
+          "MaxAttempts": 3,
+          "Comment": "Sporadic Libcurl error",
+          "MaxDelaySeconds": 300
+        }
       ]
     },
     "Get sample metadata": {


### PR DESCRIPTION
Resolved in #59 but accidentally overridden in #58